### PR TITLE
Fix for cubic root function. Cubic root added to unit tests.

### DIFF
--- a/include/VecCore/VecMath.h
+++ b/include/VecCore/VecMath.h
@@ -355,7 +355,13 @@ VECCORE_FORCE_INLINE
 VECCORE_ATT_HOST_DEVICE
 T Cbrt(const T &x)
 {
-  return std::cbrt(x);
+  T roots;
+  int v_size = vecCore::VectorSize(x);
+  for(int j = 0; j < v_size; j++) {
+    Scalar<T> scalar = vecCore::Get(x, j);
+    vecCore::Set(roots, j, std::cbrt(scalar));
+  }
+  return roots;
 }
 
 template <typename T>

--- a/test/mathtest.cc
+++ b/test/mathtest.cc
@@ -113,13 +113,13 @@ TEST_MATH_FUNCTION(ATan, atan);
 TEST_MATH_FUNCTION(Exp, exp);
 TEST_MATH_FUNCTION_POS(Log, log);
 TEST_MATH_FUNCTION_POS(Sqrt, sqrt);
-// TEST_MATH_FUNCTION(Cbrt, cbrt);
+TEST_MATH_FUNCTION(Cbrt, cbrt);
 
 TEST_MATH_FUNCTION_2(ATan2, atan2);
 TEST_MATH_FUNCTION_2(CopySign, copysign);
 TEST_MATH_FUNCTION_2(Pow, pow);
 
-REGISTER_TYPED_TEST_CASE_P(MathFunctions, Abs, Floor, Ceil, Sin, ASin, Cos, Tan, ATan, Exp, Log, Sqrt, ATan2, CopySign,
+REGISTER_TYPED_TEST_CASE_P(MathFunctions, Abs, Floor, Ceil, Sin, ASin, Cos, Tan, ATan, Exp, Log, Sqrt, Cbrt, ATan2, CopySign,
                            Pow);
 
 #define TEST_BACKEND_P(name, x) INSTANTIATE_TYPED_TEST_CASE_P(name, MathFunctions, FloatTypes<vecCore::backend::x>);


### PR DESCRIPTION
I'm working on vectorizing some shapes for VecGeom, specifically the torus, and I realized cubic root in vecCore::math::Cbrt is failing. I did some research into the code and I noticed that even the tests for it were commented so I went ahead and tried to come up with a fix for the issue.