### PR TITLE
Move fallback VcVector to namespace vecCore::backend

### DIFF
--- a/include/VecCore/Backend/Vc.h
+++ b/include/VecCore/Backend/Vc.h
@@ -17,9 +17,13 @@
 #ifndef Vc_IMPL_Scalar
 #include "VcVector.h"
 #else
+namespace vecCore {
+namespace backend {
 template <typename T>
 using VcVectorT = VcScalarT<T>;
 using VcVector  = VcScalar;
+} // namespace backend
+} // namespace vecCore
 #endif
 
 #include "VcSimdArray.h"


### PR DESCRIPTION
This fixes build errors with `Vc_IMPL=Scalar`. Note that tests still
fail to build.