### PR TITLE
build: Allow using external/system gtest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(VC      "Enable Vc backend")
 option(BUILD_DOCS         "Build doxygen documentation")
 option(BUILD_BENCHMARKS   "Build binaries for performance benchmarking")
 option(BUILD_TESTING      "Build test binaries and create test target")
-option(USE_EXTERNAL_GTEST "Use external gtest")
+option(USE_EXTERNAL_GTEST "Use external gtest" ON)
 
 option(BUILD_UMESIMD  "Build UME::SIMD library from source")
 option(BUILD_VC       "Build Vc library from source")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,9 +14,10 @@ option(CUDA    "Enable support for CUDA")
 option(UMESIMD "Enable UME::SIMD backend")
 option(VC      "Enable Vc backend")
 
-option(BUILD_DOCS       "Build doxygen documentation")
-option(BUILD_BENCHMARKS "Build binaries for performance benchmarking")
-option(BUILD_TESTING    "Build test binaries and create test target")
+option(BUILD_DOCS         "Build doxygen documentation")
+option(BUILD_BENCHMARKS   "Build binaries for performance benchmarking")
+option(BUILD_TESTING      "Build test binaries and create test target")
+option(USE_EXTERNAL_GTEST "Use external gtest")
 
 option(BUILD_UMESIMD  "Build UME::SIMD library from source")
 option(BUILD_VC       "Build Vc library from source")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,14 @@
 # VecCore Tests
 
-add_subdirectory(gtest EXCLUDE_FROM_ALL)
+if(USE_EXTERNAL_GTEST)
+  find_package(PkgConfig)
+  pkg_check_modules(GTEST QUIET gtest)
+  if(NOT GTEST_FOUND)
+    message(FATAL_ERROR "gtest not found but required when USE_EXTERNAL_GTEST is enabled.")
+  endif()
+else(USE_EXTERNAL_GTEST)
+  add_subdirectory(gtest EXCLUDE_FROM_ALL)
+endif()
 
 if (CUDA)
   add_subdirectory(cuda)


### PR DESCRIPTION
Add new option `USE_EXTERNAL_GTEST` (`OFF` by default) to allow using system installed `gtest` instead of building it in source.