### PR TITLE
Mark all Mask{Empty,Full} as VECCORE_ATT_HOST_DEVICE

### DIFF
--- a/include/VecCore/Backend/Deprecated.h
+++ b/include/VecCore/Backend/Deprecated.h
@@ -64,8 +64,10 @@ void StoreMask(M const &mask, bool *ptr)
 // Masking
 
 template <typename M>
+VECCORE_ATT_HOST_DEVICE
 bool MaskFull(const M &mask);
 template <typename M>
+VECCORE_ATT_HOST_DEVICE
 bool MaskEmpty(const M &mask);
 
 template <typename M>

--- a/include/VecCore/Backend/Implementation.h
+++ b/include/VecCore/Backend/Implementation.h
@@ -209,6 +209,7 @@ void Scatter(T const &v, S *ptr, Index<T> const &idx)
 // Masking
 
 template <typename M>
+VECCORE_ATT_HOST_DEVICE
 bool MaskFull(const M &mask)
 {
   for (size_t i = 0; i < VectorSize<M>(); i++)
@@ -217,6 +218,7 @@ bool MaskFull(const M &mask)
 }
 
 template <typename M>
+VECCORE_ATT_HOST_DEVICE
 bool MaskEmpty(const M &mask)
 {
   for (size_t i = 0; i < VectorSize<M>(); i++)


### PR DESCRIPTION
CUDA support in Clang requires that all definitions and declarations specify a consistent set of attributes.